### PR TITLE
test: unified test strategy — auto-glob test_*.cpp for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 *.app
 
 cmake-build-debug
+
+# Claude Code agent worktrees (transient, never committed)
+.claude/worktrees/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,8 +10,14 @@ include_directories (${Boost_INCLUDE_DIRS})
 
 include_directories(../src)
 
-add_executable(tests
-        test_write.cpp)
+# All test translation units are picked up automatically. Drop a new
+# test_<area>.cpp file in this directory and it is compiled into the single
+# `tests` executable -- no edits to this file required. See TESTING.md.
+# CONFIGURE_DEPENDS makes CMake re-glob on rebuild so CI fresh builds always
+# see new files.
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
+
+add_executable(tests ${TEST_SOURCES})
 
 target_link_libraries(tests teensy_x86_sd_stubs)
 target_link_libraries(tests teensy_x86_stubs)

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -1,0 +1,53 @@
+# Test strategy
+
+This project uses [Boost.Test](https://www.boost.org/doc/libs/release/libs/test/)
+for unit tests. All test files are compiled into a single executable
+(`test/tests`) which CI runs on every push.
+
+## Layout & conventions
+
+- **One file per area**, named `test_<area>.cpp` (e.g. `test_truncate.cpp`,
+  `test_read.cpp`). `test/CMakeLists.txt` globs `test_*.cpp`, so a new file is
+  compiled automatically — no CMake edits needed.
+- **Exactly one file defines the Boost test module.** `test_write.cpp` owns
+  `#define BOOST_TEST_MODULE ArduinoSDEmulationTests`. **No other test file may
+  define `BOOST_TEST_MODULE`** — they only `#include <boost/test/unit_test.hpp>`
+  and declare suites. (Two definitions break the link with duplicate symbols.)
+- **Wrap cases in a uniquely named suite:**
+  `BOOST_AUTO_TEST_SUITE(<area>_tests)` … `BOOST_AUTO_TEST_SUITE_END()`.
+- **Use the shared fixture** so the Arduino mock is initialized:
+  `BOOST_FIXTURE_TEST_CASE(case_name, DefaultTestFixture)` (from
+  `default_test_fixture.h`, which calls `initialize_mock_arduino()`).
+- **File-backed tests** should map a working directory via
+  `SD.setSDCardFolderPath("output", true)` and clean up artifacts they create
+  (the existing tests write under `output/`).
+
+## Minimal template
+
+```cpp
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+BOOST_AUTO_TEST_SUITE(example_tests)
+
+    BOOST_FIXTURE_TEST_CASE(does_the_thing, DefaultTestFixture) {
+        SD.setSDCardFolderPath("output", true);
+        // ... arrange / act / assert with BOOST_CHECK_* ...
+    }
+
+BOOST_AUTO_TEST_SUITE_END()
+```
+
+## Running
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=On
+cmake --build build
+./build/test/tests                                   # all tests
+./build/test/tests --run_test=example_tests/does_the_thing   # one case
+./build/test/tests --log_level=all                   # verbose
+```
+
+CI (`.github/workflows/ubuntu-x86.yml`) configures with `-DBUILD_TESTS=On`,
+builds, and runs `test/tests` emitting XML results — so any `test_*.cpp` added
+here runs in CI automatically.


### PR DESCRIPTION
Closes #14.

## Summary
Foundation for the bug-fix PRs (#5–#13). Establishes a single, unified test convention so each fix can ship with a regression test that CI runs automatically.

- **`test/CMakeLists.txt`** now globs `test_*.cpp` (`CONFIGURE_DEPENDS`) into the existing single `tests` executable. Adding a test file no longer requires a CMake edit — which also means the fix PRs don't conflict on this file.
- **`test/TESTING.md`** documents the convention: one `test_<area>.cpp` per area, exactly one file defines `BOOST_TEST_MODULE` (`test_write.cpp`), suites use the shared `DefaultTestFixture` (so `initialize_mock_arduino()` runs).

No behavior change to the library. CI already builds with `-DBUILD_TESTS=On` and runs `test/tests`, so newly added `test_*.cpp` files run automatically.

## Note
The per-bug fix PRs are **based on this branch** so their diffs show only the fix; they'll auto-retarget to `main` once this merges. Recommend merging this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_