### PR TITLE
Fix File::truncate to honor its size argument

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -25,7 +25,7 @@ uint32_t File::position() {
     return file->position();
 }
 bool File::truncate(uint64_t size) {
-    return file->truncate();
+    return file->truncate(size);
 }
 
 

--- a/test/test_file_truncate.cpp
+++ b/test/test_file_truncate.cpp
@@ -1,0 +1,46 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+BOOST_AUTO_TEST_SUITE(file_truncate_tests)
+
+    BOOST_FIXTURE_TEST_CASE(truncate_honors_size_argument, DefaultTestFixture) {
+
+        SD.setSDCardFolderPath("output", true);
+
+        if (SD.exists("truncate.txt")) {
+            SD.remove("truncate.txt");
+        }
+
+        // Write a known 11-byte string.
+        File write_file = SD.open("truncate.txt", O_WRITE);
+        if (!write_file) {
+            BOOST_FAIL("File was not opened (for write)...");
+        }
+        write_file.write((const uint8_t *)"hello world", 11);
+        write_file.close();
+
+        // Reopen and truncate to 5 bytes.
+        File trunc_file = SD.open("truncate.txt", O_READ | O_WRITE);
+        if (!trunc_file) {
+            BOOST_FAIL("File was not opened (for truncate)...");
+        }
+        BOOST_CHECK(trunc_file.truncate(5));
+        trunc_file.close();
+
+        // Reopen for read and verify the file is exactly 5 bytes ("hello").
+        File read_file = SD.open("truncate.txt", O_READ);
+        if (!read_file) {
+            BOOST_FAIL("File was not opened (for read)...");
+        }
+        BOOST_CHECK_EQUAL(read_file.size(), 5u);
+
+        const char *expected = "hello";
+        char buffer[16] = {0};
+        int numBytesRead = read_file.read(buffer, 16);
+        read_file.close();
+
+        BOOST_CHECK_EQUAL(numBytesRead, 5);
+        BOOST_CHECK_EQUAL_COLLECTIONS(&buffer[0], &buffer[5], &expected[0], &expected[5]);
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

`File::truncate(uint64_t size)` in `src/File.cpp` discarded its `size` argument and called the underlying `AbstractFile::truncate()` with no argument, which defaults to `0`. This meant every call to `truncate(n)` truncated the file to 0 bytes regardless of `n`.

The fix forwards the argument:

```cpp
bool File::truncate(uint64_t size) {
    return file->truncate(size);   // was: file->truncate();
}
```

## Regression test

Added `test/test_file_truncate.cpp` (suite `file_truncate_tests`):

- Maps a working folder via `SD.setSDCardFolderPath("output", true)`.
- Writes the 11-byte string `"hello world"` to a file and closes it.
- Reopens with `O_READ | O_WRITE`, calls `truncate(5)`, and closes.
- Reopens with `O_READ` and asserts `size() == 5` and that reading returns exactly 5 bytes (`"hello"`).

This test fails before the fix (the file would be truncated to 0 bytes) and passes after. It follows `test/TESTING.md`: no `BOOST_TEST_MODULE` definition, uses `DefaultTestFixture`, and is picked up automatically by the `test_*.cpp` glob in `test/CMakeLists.txt`.

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_