### PR TITLE
Fix LinuxFile::truncate to use the full SD path

### DIFF
--- a/src/LinuxFile.cpp
+++ b/src/LinuxFile.cpp
@@ -204,7 +204,7 @@ File LinuxFile::openNextFile(void) {
 }
 
 bool LinuxFile::truncate(uint64_t size) {
-    if (::truncate(_fileName, size) != 0)
+    if (::truncate(localFileName, size) != 0)
         return false;
     return true;
 }

--- a/test/test_linuxfile_truncate.cpp
+++ b/test/test_linuxfile_truncate.cpp
@@ -1,0 +1,64 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+#include <cstdio>
+#include <fstream>
+
+BOOST_AUTO_TEST_SUITE(linuxfile_truncate_tests)
+
+    // Regression for issue #6: LinuxFile::truncate must operate on the file
+    // under the SD folder (localFileName), not on the bare filename relative
+    // to the process CWD. Before the fix, ::truncate received the bare name,
+    // so the file under the SD folder was left unchanged.
+    BOOST_FIXTURE_TEST_CASE(truncate_targets_file_under_sd_folder, DefaultTestFixture) {
+
+        SD.setSDCardFolderPath("output", true);
+
+        const char *fileName = "truncate_me.txt";
+
+        if (SD.exists(fileName)) {
+            SD.remove(fileName);
+        }
+        // Make sure no stray file from a previous run sits in the CWD.
+        std::remove(fileName);
+
+        // Arrange: write known content to the file under the SD folder.
+        File write_file = SD.open(fileName, O_WRITE);
+        if (!write_file) {
+            BOOST_FAIL("File was not opened (for write)...");
+        }
+        write_file.write((const uint8_t *)"hello world", 11);
+        write_file.close();
+
+        // Act: open the file and truncate it.
+        File trunc_file = SD.open(fileName, O_READ | O_WRITE);
+        if (!trunc_file) {
+            BOOST_FAIL("File was not opened (for truncate)...");
+        }
+        BOOST_CHECK(trunc_file.truncate(0));
+        trunc_file.close();
+
+        // Assert: the file UNDER THE SD FOLDER is now empty. Reopening via SD
+        // recomputes the size from disk, so size() reflects the truncation.
+        File read_file = SD.open(fileName, O_READ);
+        if (!read_file) {
+            BOOST_FAIL("File was not opened (for read)...");
+        }
+        BOOST_CHECK_EQUAL(read_file.size(), 0u);
+        read_file.close();
+
+        // And confirm directly on disk that the SD-folder file shrank.
+        std::ifstream onDisk("output/truncate_me.txt", std::ios::binary | std::ios::ate);
+        BOOST_REQUIRE(onDisk.is_open());
+        BOOST_CHECK_EQUAL((long)onDisk.tellg(), 0L);
+        onDisk.close();
+
+        // And confirm no stray file was created in the process CWD (the old
+        // buggy behaviour would have aimed ::truncate at "truncate_me.txt"
+        // in the CWD).
+        std::ifstream stray("truncate_me.txt", std::ios::binary);
+        BOOST_CHECK(!stray.is_open());
+        if (stray.is_open()) stray.close();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Fix

`LinuxFile::truncate` passed `_fileName` (the bare filename, e.g. `test.txt`) to `::truncate`, so it operated on a path relative to the process CWD instead of the file under the SD folder. The constructor already builds `localFileName`, the fully-qualified path under `getSDCardFolderPath()`. The fix passes `localFileName` to `::truncate` instead.

```cpp
bool LinuxFile::truncate(uint64_t size) {
    if (::truncate(localFileName, size) != 0)
        return false;
    return true;
}
```

## Test

Adds `test/test_linuxfile_truncate.cpp` (suite `linuxfile_truncate_tests`, picked up automatically by the `test_*.cpp` glob — no CMake edit needed). The regression test:

- Maps `output/` as the SD folder via `SD.setSDCardFolderPath("output", true)`.
- Writes known content to a file under the SD folder and closes it.
- Reopens it, calls `truncate`, and closes.
- Asserts the file UNDER the SD folder is now empty (via `SD.open(...).size()` and a direct on-disk `std::ifstream` check of `output/...`).
- Asserts no stray file was created in the process CWD (the old buggy target).

Before the fix, `::truncate` aimed at the wrong path, leaving the SD-folder file unchanged, so the test fails; after the fix it passes.

Note: the test truncates to `0` because `File::truncate` currently forwards to `file->truncate()` with the default size; that is a separate concern out of scope here.

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_