### PR TITLE
Initialize SDClass members in their declarations

### DIFF
--- a/src/SD.h
+++ b/src/SD.h
@@ -147,9 +147,9 @@ private:
     SdFile getParentDir(const char *filepath, int *indx);
 
     std::string _sdCardFolderLocation;
-    bool _useMockData;
-    char *_fileData;
-    uint32_t _fileSize;
+    bool _useMockData = false;
+    char *_fileData = nullptr;
+    uint32_t _fileSize = 0;
 
 public:
     SDClass() {

--- a/test/test_sdclass_init.cpp
+++ b/test/test_sdclass_init.cpp
@@ -1,0 +1,17 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+BOOST_AUTO_TEST_SUITE(sdclass_init_tests)
+
+    // Determinism check for issue #9: the default constructor used to leave
+    // _useMockData, _fileData and _fileSize indeterminate, yet begin() reads
+    // them. With the in-class member initializers a freshly constructed SDClass
+    // has no folder and no mock data, so begin() must deterministically return
+    // false before any setter is called. (Before the fix the members were
+    // indeterminate and begin() could return either value.)
+    BOOST_FIXTURE_TEST_CASE(fresh_sdclass_begin_is_false, DefaultTestFixture) {
+        SDClass localSd;
+        BOOST_CHECK_EQUAL(localSd.begin(), false);
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Fix

`SDClass`'s default constructor (used by the global `SD` object) left `_useMockData`, `_fileData` and `_fileSize` uninitialized. These members are read by `begin()` and `open()`, so the global `SD`'s behavior depended on indeterminate memory.

This adds in-class member initializers so the defaults are deterministic:

```cpp
std::string _sdCardFolderLocation;
bool _useMockData = false;
char *_fileData = nullptr;
uint32_t _fileSize = 0;
```

Both constructors (default and the `std::string` folder-path overload) now leave all members well-defined. No other behavior changes — the string-path constructor still sets `_sdCardFolderLocation` and inherits the new defaults for the rest.

## Test

Adds `test/test_sdclass_init.cpp` (suite `sdclass_init_tests`, `DefaultTestFixture`, no `BOOST_TEST_MODULE`). It constructs a fresh local `SDClass` and asserts `begin()` returns `false` before any setter is called — i.e. with no folder and no mock data the result is deterministically false. This exercises that `_fileData`/`_fileSize`/`_useMockData` are well-defined (before the fix they were indeterminate and `begin()` could return either value). Picked up automatically by the `test_*.cpp` glob; `test/CMakeLists.txt` unchanged.

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_