### PR TITLE
Fix LinuxFile::read to signal EOF and avoid sign extension

### DIFF
--- a/src/LinuxFile.cpp
+++ b/src/LinuxFile.cpp
@@ -115,9 +115,14 @@ size_t LinuxFile::write(const uint8_t *buf, size_t size) {
 }
 
 int LinuxFile::read() {
-    char p[1];
-    mockFile.read(p, 1);
-    return p[0];
+    if (! mockFile.is_open())
+        return -1;
+
+    char p;
+    if (!mockFile.read(&p, 1))
+        return -1;   // EOF or error
+
+    return static_cast<unsigned char>(p);
 }
 
 int LinuxFile::peek() {

--- a/test/test_linuxfile_read_eof.cpp
+++ b/test/test_linuxfile_read_eof.cpp
@@ -1,0 +1,60 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+BOOST_AUTO_TEST_SUITE(linuxfile_read_eof_tests)
+
+    BOOST_FIXTURE_TEST_CASE(read_returns_minus_one_at_eof, DefaultTestFixture) {
+        SD.setSDCardFolderPath("output", true);
+
+        if (SD.exists("eof.txt")) {
+            SD.remove("eof.txt");
+        }
+
+        File write_file = SD.open("eof.txt", O_WRITE);
+        if (!write_file) {
+            BOOST_FAIL("File was not opened (for write)...");
+        }
+        write_file.write((const uint8_t *)"abc", 3);
+        write_file.close();
+
+        File read_file = SD.open("eof.txt", O_READ);
+        if (!read_file) {
+            BOOST_FAIL("File was not opened (for read)...");
+        }
+
+        BOOST_CHECK_EQUAL(read_file.read(), (int)'a');
+        BOOST_CHECK_EQUAL(read_file.read(), (int)'b');
+        BOOST_CHECK_EQUAL(read_file.read(), (int)'c');
+
+        // Past the end of the file: read() must signal EOF with -1.
+        BOOST_CHECK_EQUAL(read_file.read(), -1);
+
+        read_file.close();
+    }
+
+    BOOST_FIXTURE_TEST_CASE(read_high_byte_is_not_sign_extended, DefaultTestFixture) {
+        SD.setSDCardFolderPath("output", true);
+
+        if (SD.exists("highbyte.txt")) {
+            SD.remove("highbyte.txt");
+        }
+
+        File write_file = SD.open("highbyte.txt", O_WRITE);
+        if (!write_file) {
+            BOOST_FAIL("File was not opened (for write)...");
+        }
+        write_file.write((uint8_t)0xFE);
+        write_file.close();
+
+        File read_file = SD.open("highbyte.txt", O_READ);
+        if (!read_file) {
+            BOOST_FAIL("File was not opened (for read)...");
+        }
+
+        // A byte >= 0x80 must come back as a positive value, not sign-extended.
+        BOOST_CHECK_EQUAL(read_file.read(), 254);
+
+        read_file.close();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Problem

`LinuxFile::read()` read a single byte into a buffer and returned it directly:

```cpp
int LinuxFile::read() {
    char p[1];
    mockFile.read(p, 1);
    return p[0];
}
```

Two bugs:
1. **No EOF check.** Arduino's `Stream::read()` contract requires returning `-1` at end of file/error, but this returned whatever happened to be in the buffer.
2. **Sign extension.** `char` is signed on most platforms, so any byte `>= 0x80` (e.g. `0xFE`) was sign-extended to a negative `int` instead of the intended `0`–`255` value.

## Fix

```cpp
int LinuxFile::read() {
    if (! mockFile.is_open())
        return -1;

    char p;
    if (!mockFile.read(&p, 1))
        return -1;   // EOF or error

    return static_cast<unsigned char>(p);
}
```

- Returns `-1` when the file is not open (consistent with the existing `is_open()` guards used by `peek()`, `available()`, `seek()`, etc.).
- Returns `-1` on EOF/read error.
- Casts through `unsigned char` so high bytes come back as positive `0`–`255` values.

## Tests

Added `test/test_linuxfile_read_eof.cpp` (suite `linuxfile_read_eof_tests`, no `BOOST_TEST_MODULE`, uses `DefaultTestFixture`):
- **EOF:** writes 3 bytes `"abc"`, reopens `O_READ`, reads and verifies each byte, then asserts the next `read()` returns `-1`.
- **High byte:** writes `0xFE` via `write((uint8_t)0xFE)`, reopens `O_READ`, asserts `read()` returns `254` (not negative).

The test file is picked up automatically by the `test_*.cpp` glob in `test/CMakeLists.txt`, so no CMake changes are needed.

Closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_