### PR TITLE
Fix LinuxFile::write size tracking on seek/overwrite

### DIFF
--- a/src/LinuxFile.cpp
+++ b/src/LinuxFile.cpp
@@ -100,14 +100,16 @@ size_t LinuxFile::write(const uint8_t *buf, size_t size) {
         return 0;
     }
 
-    _size += size;
     char * memblock = (char *)buf;
-
 
     size_t before = mockFile.tellp(); //current pos
     if (mockFile.write(memblock, size)) {
+        size_t after = mockFile.tellp();
         //compute the difference
-        size_t numberOfBytesWritten = (size_t)mockFile.tellp() - before;
+        size_t numberOfBytesWritten = after - before;
+        //grow size only if the write extended past the current end-of-file
+        if ((int32_t)after > _size)
+            _size = (int32_t)after;
         return numberOfBytesWritten;
     }
 

--- a/test/test_linuxfile_write_size.cpp
+++ b/test/test_linuxfile_write_size.cpp
@@ -1,0 +1,49 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+BOOST_AUTO_TEST_SUITE(linuxfile_write_size_tests)
+
+    // Regression for issue #7: writing in place after a seek must not inflate
+    // size(). The key assertion is on the live (still-open) file handle, since
+    // reopening recomputes size from disk and would mask the bug.
+    BOOST_FIXTURE_TEST_CASE(seek_overwrite_does_not_inflate_size, DefaultTestFixture) {
+
+        const char *expected = "hello universe";
+
+        SD.setSDCardFolderPath("output", true);
+
+        if (SD.exists("test_write_size.txt")) {
+            SD.remove("test_write_size.txt");
+        }
+
+        File write_file = SD.open("test_write_size.txt", O_READ | O_WRITE | O_TRUNC);
+        if (!write_file) {
+            BOOST_FAIL("File was not opened (for write)...");
+        }
+
+        write_file.write((const uint8_t *)"hello world", 11);
+        BOOST_CHECK_EQUAL(write_file.size(), 11);
+
+        write_file.seek(6);
+        write_file.write((const uint8_t *)"universe", 8);
+
+        // seek(6) + write(8) on an 11-byte file ends at position 14, so the file
+        // is 14 bytes -- not 11 + 8 == 19. Assert on the live handle.
+        BOOST_CHECK_EQUAL(write_file.size(), 14);
+
+        write_file.close();
+
+        File read_file = SD.open("test_write_size.txt", O_READ);
+        if (!read_file) {
+            BOOST_FAIL("File was not opened (for read)...");
+        }
+        BOOST_CHECK_EQUAL(read_file.size(), 14);
+
+        char buffer[14];
+        int numBytesRead = read_file.read(buffer, 20);
+        BOOST_CHECK_EQUAL(numBytesRead, 14);
+        BOOST_CHECK_EQUAL_COLLECTIONS(&buffer[0], &buffer[13], &expected[0], &expected[13]);
+        read_file.close();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Problem

`LinuxFile::write` added the written byte count to `_size` unconditionally before writing:

```cpp
_size += size;
```

This inflated `size()` whenever a file was overwritten in place after a `seek()`. For example, on an 11-byte file, `seek(6)` + `write(8 bytes)` reported `size()` as 19 instead of the correct 14.

Fixes #7.

## Fix

`src/LinuxFile.cpp`: removed the unconditional `_size += size;` and instead derive the end-of-file from the actual stream position after the write. `_size` now grows only when the write extends past the current end-of-file (`max(old size, new position)`):

```cpp
size_t before = mockFile.tellp();
if (mockFile.write(memblock, size)) {
    size_t after = mockFile.tellp();
    size_t numberOfBytesWritten = after - before;
    if ((int32_t)after > _size)
        _size = (int32_t)after;
    return numberOfBytesWritten;
}
```

`_size` is `int32_t` and `tellp()` returns `streampos`, so the comparison/assignment are explicitly cast.

## Test

Added `test/test_linuxfile_write_size.cpp` (suite `linuxfile_write_size_tests`, fixture `DefaultTestFixture`, no `BOOST_TEST_MODULE`):

- Opens a file, writes `"hello world"` (11 bytes), checks `size()` == 11.
- `seek(6)`, writes `"universe"` (8 bytes), then asserts `size()` == 14 (not 19) **on the still-open handle** — this is the key regression assertion, since reopening recomputes size from disk and would mask the bug.
- Closes, reopens `O_READ`, and verifies content is `"hello universe"` and size 14.

`test/CMakeLists.txt` globs `test_*.cpp`, so no CMake edits are needed.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_