### PR TITLE
Skip . and .. and close DIR in LinuxFile::openNextFile

### DIFF
--- a/src/LinuxFile.cpp
+++ b/src/LinuxFile.cpp
@@ -15,6 +15,7 @@
 #include "SD.h"
 
 #include <string>
+#include <cstring>
 #include <unistd.h>
 
 LinuxFile::LinuxFile(const char *name, const char *path, uint8_t mode, SDClass &sd) : AbstractFile(name), _sd(sd) {
@@ -185,20 +186,22 @@ File LinuxFile::openNextFile(void) {
     if (isCurrentFileADirectory){
         while (true) {
             entry = readdir(dp);
-        
+
             if (entry != NULL) {
+                if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+                    continue;
                 auto l = _sd.getSDCardFolderPath().length();
                 std::string lfnString = std::string( localFileName );
                 std::string final = lfnString.substr(l+1, lfnString.length()-l-1);
                 File f = File(new LinuxFile(entry->d_name, final.c_str(), O_READ, this->_sd));
                 return f;
-            } else 
+            } else
                 break;
         }
     }
 
-    
-    //closedir(dp);
+    closedir(dp);
+    dp = NULL;
 
     return File( new InMemoryFile());
 }

--- a/test/test_opennextfile.cpp
+++ b/test/test_opennextfile.cpp
@@ -1,0 +1,64 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+BOOST_AUTO_TEST_SUITE(opennextfile_tests)
+
+    BOOST_FIXTURE_TEST_CASE(skips_dot_and_dotdot_and_lists_children, DefaultTestFixture) {
+        SD.setSDCardFolderPath("output", true);
+
+        const char *subdir = "onf_dir";
+        const char *fileA = "onf_dir/alpha.txt";
+        const char *fileB = "onf_dir/beta.txt";
+
+        // Clean any leftovers from a previous run.
+        SD.remove(fileA);
+        SD.remove(fileB);
+        SD.rmdir(subdir);
+
+        // Arrange: create a subdirectory with two known files.
+        BOOST_REQUIRE(SD.mkdir(subdir));
+
+        File wa = SD.open(fileA, O_WRITE);
+        BOOST_REQUIRE(wa);
+        wa.write((const uint8_t *)"a", 1);
+        wa.close();
+
+        File wb = SD.open(fileB, O_WRITE);
+        BOOST_REQUIRE(wb);
+        wb.write((const uint8_t *)"b", 1);
+        wb.close();
+
+        // Act: iterate the directory collecting child names.
+        File dir = SD.open(subdir, O_READ);
+        BOOST_REQUIRE(dir);
+        BOOST_REQUIRE(dir.isDirectory());
+
+        std::vector<std::string> names;
+        while (true) {
+            File child = dir.openNextFile();
+            if (!child)
+                break;
+            names.push_back(std::string(child.name()));
+            child.close();
+        }
+        dir.close();
+
+        // Assert: "." and ".." pseudo-entries are not returned.
+        BOOST_CHECK(std::find(names.begin(), names.end(), std::string(".")) == names.end());
+        BOOST_CHECK(std::find(names.begin(), names.end(), std::string("..")) == names.end());
+
+        // Assert: the known files are present.
+        BOOST_CHECK(std::find(names.begin(), names.end(), std::string("alpha.txt")) != names.end());
+        BOOST_CHECK(std::find(names.begin(), names.end(), std::string("beta.txt")) != names.end());
+
+        // Clean up artifacts.
+        SD.remove(fileA);
+        SD.remove(fileB);
+        SD.rmdir(subdir);
+    }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_opennextfile.cpp
+++ b/test/test_opennextfile.cpp
@@ -23,18 +23,20 @@ BOOST_AUTO_TEST_SUITE(opennextfile_tests)
         BOOST_REQUIRE(SD.mkdir(subdir));
 
         File wa = SD.open(fileA, O_WRITE);
-        BOOST_REQUIRE(wa);
+        // File::operator bool() is non-const, so convert explicitly before
+        // handing the result to a Boost assertion (which takes a const ref).
+        if (!wa) BOOST_FAIL("could not open alpha.txt for write");
         wa.write((const uint8_t *)"a", 1);
         wa.close();
 
         File wb = SD.open(fileB, O_WRITE);
-        BOOST_REQUIRE(wb);
+        if (!wb) BOOST_FAIL("could not open beta.txt for write");
         wb.write((const uint8_t *)"b", 1);
         wb.close();
 
         // Act: iterate the directory collecting child names.
         File dir = SD.open(subdir, O_READ);
-        BOOST_REQUIRE(dir);
+        if (!dir) BOOST_FAIL("could not open onf_dir for read");
         BOOST_REQUIRE(dir.isDirectory());
 
         std::vector<std::string> names;


### PR DESCRIPTION
## Problem

`LinuxFile::openNextFile` (in `src/LinuxFile.cpp`) iterates a directory with `readdir` but:

1. Returned the `.` and `..` pseudo-entries as if they were real children.
2. Never closed the `DIR` handle on exhaustion — `closedir(dp)` was commented out, leaking the handle.

## Fix

- In the `readdir` loop, skip entries whose `d_name` is `"."` or `".."` via `strcmp(...) == 0 ? continue : ...`.
- When `readdir` returns `NULL` (enumeration exhausted), call `closedir(dp); dp = NULL;` before returning the `InMemoryFile()` sentinel.
- Added `#include <cstring>` so `strcmp` is guaranteed available.

The existing structure/behavior is otherwise preserved: it still returns the next `LinuxFile` child, or a falsy `InMemoryFile` sentinel when enumeration is done.

## Test

Added `test/test_opennextfile.cpp` (suite `opennextfile_tests`, `DefaultTestFixture`, no `BOOST_TEST_MODULE` — picked up automatically by the `test_*.cpp` glob):

- Maps `output/` as the SD root, creates a subdirectory with two known files (`alpha.txt`, `beta.txt`).
- Opens the directory and iterates with `openNextFile()` until the returned `File` is falsy.
- Asserts `.` and `..` are NOT among the returned names, and that both known files ARE present.
- Cleans up the created artifacts.

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_