### PR TITLE
Fix file object leaks and add virtual destructor

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -5,7 +5,7 @@ const char *File::name(void) {
     return file->_fileName;
 }
 
-File::File(AbstractFile *abs) : file(abs) {
+File::File(AbstractFile *abs) : file(std::shared_ptr<AbstractFile>(abs)) {
 
 }
 
@@ -36,8 +36,11 @@ uint32_t File::size() {
 void File::close() {
     if (file != nullptr) {
         file->close();
-        file = nullptr;
-    } else 
+        // Release this File's reference to the impl. The underlying
+        // AbstractFile is destroyed once the last shared_ptr (across all
+        // copies of this File) is released.
+        file.reset();
+    } else
     {
         Serial.println("WARNING: File::close() - file is already closed!!!!");
     }

--- a/src/LinuxFile.cpp
+++ b/src/LinuxFile.cpp
@@ -61,6 +61,16 @@ LinuxFile::LinuxFile(const char *name, const char *path, uint8_t mode, SDClass &
     _fileName = name;
 }
 
+LinuxFile::~LinuxFile() {
+    if (mockFile.is_open())
+        mockFile.close();
+    if (dp != NULL)
+        closedir(dp);
+    // localFileName is declared `const char *`; cast away const to delete[].
+    delete[] (char*)localFileName;
+    delete[] localPath;
+}
+
 std::streampos LinuxFile::fileSize( const char* filePath ){
     std::streampos fsize = 0;
     std::ifstream file( filePath, std::ios::binary );

--- a/src/SD.h
+++ b/src/SD.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdint>
+#include <memory>
 
 #define BUILTIN_SDCARD 254
 
@@ -28,6 +29,8 @@ namespace SDLib {
 
         explicit AbstractFile(const char *fileName);
 
+        virtual ~AbstractFile() = default;
+
         virtual bool isDirectory() = 0;
         int read() override = 0;
         virtual int read(void *buf, uint32_t nbyte) = 0;
@@ -43,7 +46,7 @@ namespace SDLib {
 
 class File : public Stream {
 protected:
-    AbstractFile *file;
+    std::shared_ptr<AbstractFile> file;
 
 public:
 
@@ -81,6 +84,7 @@ private:
 public:
     InMemoryFile(const char *name, char *data, uint32_t size, uint8_t mode = O_READ);
     InMemoryFile(void);      // 'empty' constructor
+    ~InMemoryFile() override = default;  // does NOT own _data (borrowed from caller)
     bool isDirectory(void) override;
     size_t write(uint8_t) override;
     size_t write(const uint8_t *buf, size_t size) override;
@@ -103,14 +107,15 @@ public:
 
 class LinuxFile : public AbstractFile {
 private:
-    const char * localFileName;
-    char * localPath;
+    const char * localFileName = nullptr;
+    char * localPath = nullptr;
     const char * _path;
     std::fstream mockFile = std::fstream();
     DIR *dp = NULL;
 public:
     LinuxFile(const char *name, const char *path, uint8_t mode = O_READ, SDClass &sd = SD);
     LinuxFile(SDClass &sd = SD);
+    ~LinuxFile() override;
 
     static std::streampos fileSize( const char* filePath );
     static bool is_directory( const char* pzPath );

--- a/test/test_file_lifecycle.cpp
+++ b/test/test_file_lifecycle.cpp
@@ -1,0 +1,95 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+#include <string>
+
+// These tests exercise the File open/close lifecycle and File value-copy
+// ownership semantics introduced when File began owning its AbstractFile impl
+// via std::shared_ptr (issue #10). They guard against use-after-free and
+// double-free regressions.
+//
+// NOTE: true memory-leak detection requires a sanitizer build
+// (e.g. -fsanitize=address) which is out of scope here. These cases verify
+// the lifecycle/ownership *behavior* does not crash and produces correct reads.
+
+BOOST_AUTO_TEST_SUITE(file_lifecycle_tests)
+
+    // Open (write then read) a file many times to exercise the
+    // new/shared_ptr/close path repeatedly without crashing.
+    BOOST_FIXTURE_TEST_CASE(repeated_open_close_does_not_crash, DefaultTestFixture) {
+        SD.setSDCardFolderPath("output", true);
+
+        const char *expected = "hello world";
+        const int iterations = 100;
+
+        for (int i = 0; i < iterations; i++) {
+            if (SD.exists("lifecycle.txt")) {
+                SD.remove("lifecycle.txt");
+            }
+
+            File write_file = SD.open("lifecycle.txt", O_WRITE);
+            if (!write_file) {
+                BOOST_FAIL("File was not opened (for write)...");
+            }
+            write_file.write((const uint8_t *)expected, 11);
+            write_file.close();
+
+            File read_file = SD.open("lifecycle.txt", O_READ);
+            if (!read_file) {
+                BOOST_FAIL("File was not opened (for read)...");
+            }
+            char buffer[11] = {0};
+            int numBytesRead = read_file.read(buffer, 11);
+            BOOST_CHECK_EQUAL(numBytesRead, 11);
+            BOOST_CHECK_EQUAL_COLLECTIONS(&buffer[0], &buffer[10],
+                                          &expected[0], &expected[10]);
+            read_file.close();
+        }
+
+        if (SD.exists("lifecycle.txt")) {
+            SD.remove("lifecycle.txt");
+        }
+    }
+
+    // Copying a File shares ownership of the underlying impl. Closing one copy
+    // must not leave the other dangling, and the impl must be freed exactly
+    // once (no double-free) when the last copy goes away.
+    BOOST_FIXTURE_TEST_CASE(copying_file_then_closing_is_safe, DefaultTestFixture) {
+        SD.setSDCardFolderPath("output", true);
+
+        const char *expected = "hello world";
+
+        if (SD.exists("copy.txt")) {
+            SD.remove("copy.txt");
+        }
+
+        File write_file = SD.open("copy.txt", O_WRITE);
+        if (!write_file) {
+            BOOST_FAIL("File was not opened (for write)...");
+        }
+        write_file.write((const uint8_t *)expected, 11);
+        write_file.close();
+
+        {
+            File a = SD.open("copy.txt", O_READ);
+            if (!a) {
+                BOOST_FAIL("File was not opened (for read)...");
+            }
+            File b = a;   // shares ownership of the impl
+
+            char buffer[11] = {0};
+            int numBytesRead = b.read(buffer, 11);
+            BOOST_CHECK_EQUAL(numBytesRead, 11);
+
+            // Close through one handle; the other still refers to the (now
+            // closed) shared impl, which is freed when the last copy drops.
+            a.close();
+            // b goes out of scope here without an explicit close().
+        }
+
+        if (SD.exists("copy.txt")) {
+            SD.remove("copy.txt");
+        }
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Fixes the memory leaks and undefined behavior described in issue #10.

### Problems
- `SDClass::open` / `openNextFile()` do `new InMemoryFile/LinuxFile`, but `File::close()` only nulled the raw pointer — the impl object was never deleted (leak).
- `AbstractFile` had virtual methods but **no virtual destructor**, so deleting through a base pointer was undefined behavior.
- `LinuxFile` allocates `localFileName` and `localPath` with `new char[]` and never freed them (leak).
- `File`'s copy constructor was a shallow pointer copy, and `File` is returned/copied by value — so two `File`s could point at the same impl, making manual `delete` unsafe (double-free risk).

### Changes (ownership model)
- **`AbstractFile`**: added `virtual ~AbstractFile() = default;` so destruction through the base pointer is well-defined.
- **`File`**: changed the member from raw `AbstractFile *` to `std::shared_ptr<AbstractFile>`. Value-copies of `File` now **share ownership**; the impl is destroyed when the last copy is released. The existing `File(AbstractFile *)` signature is preserved (it wraps the raw `new`'d pointer in the shared_ptr, taking sole ownership). The copy constructor now shares ownership. `File::close()` calls `file->close()` then `file.reset()` (preserving the existing nullptr-guard warning).
- **`LinuxFile`**: added a destructor that `delete[]`s `localFileName` (cast away `const`) and `localPath`, closes the open fstream, and closes any open `DIR*`. Members are now default-initialized to `nullptr` so the destructor is safe even when a path has no slash component.
- **`InMemoryFile`**: added an explicit `~InMemoryFile() = default;` with a comment — it does **not** own `_data` (borrowed from the caller), so nothing is freed there.

Each raw `new` is handed to exactly one `File`, so there is no double-free.

### Test
Added `test/test_file_lifecycle.cpp` (no `BOOST_TEST_MODULE`, uses `DefaultTestFixture`, suite `file_lifecycle_tests`). It:
- Opens (write then read) a file 100 times to exercise the open/close lifecycle without crashing, asserting reads succeed each iteration.
- Copies a `File` (`File a = SD.open(...); File b = a;`), reads via the copy, then closes one handle and lets the other drop — verifying shared-ownership close works without crash/double-free.

A comment notes that true leak detection requires a sanitizer build (out of scope here); this test guards lifecycle/ownership behavior. `test/CMakeLists.txt` was not edited (it globs `test_*.cpp`).

### Note
⚠️ This is the **most invasive** of the issue fixes — it changes the `File` member type and adds a `LinuxFile` destructor. It may conflict with other PRs that touch `LinuxFile` (e.g. its path handling / member buffers); rebase ordering may be needed.

Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_