### PR TITLE
Replace system() shell-outs with std::filesystem

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(teensy_x86_sd_stubs C CXX)
 set(teensy_x86_sd_stubs_VERSION 1.0.0)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 set(SOURCE_FILES
 		File.cpp
@@ -26,3 +26,7 @@ set(UTILITY_HEADER_FILES
 		utility/SdInfo.h)
 
 add_library(teensy_x86_sd_stubs SHARED STATIC ${HEADER_FILES} ${UTILITY_HEADER_FILES} ${SOURCE_FILES})
+
+# <filesystem> requires C++17. Expose this as a PUBLIC requirement so consumers
+# (e.g. the test executable) inherit the C++17 standard transitively.
+target_compile_features(teensy_x86_sd_stubs PUBLIC cxx_std_17)

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -52,7 +52,11 @@
 #include <stdio.h>
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 #include "SD.h"
+
+namespace fs = std::filesystem;
+
 namespace SDLib {
 
 // Used by `getNextPathComponent`
@@ -467,10 +471,15 @@ bool SDClass::mkdir(const char *filepath) {
 		path = _sdCardFolderLocation + "/" + std::string(filepath);
 
     if (!exists(path.c_str())) {
-        std::string cmd = std::string("mkdir -p \"") + std::string(path) + "\"";
-        int result = system(cmd.c_str());
-    	if (result != 0) Serial.printf("Unable to mkdir '%s'\n", filepath);
-        return result == 0;
+        try {
+            // create_directories returns false if the directory already
+            // exists; treat that as success to mirror the previous behaviour.
+            fs::create_directories(path);
+        } catch (const std::exception &e) {
+            Serial.printf("Unable to mkdir '%s'\n", filepath);
+            return false;
+        }
+        return true;
     }
     return true;
 }
@@ -481,8 +490,11 @@ bool SDClass::rmdir(const char *filepath) {
 
     std::string path = _sdCardFolderLocation + "/" + std::string(filepath);
     if (exists(filepath)) {
-        std::string cmd = std::string("rm -rf ") + std::string(path);
-        system(cmd.c_str());
+        try {
+            fs::remove_all(path);
+        } catch (const std::exception &e) {
+            Serial.printf("Unable to rmdir '%s'\n", filepath);
+        }
         return true;
     }
     return true;
@@ -491,11 +503,14 @@ bool SDClass::rmdir(const char *filepath) {
 bool SDClass::remove(const char *filepath) {
     if (_sdCardFolderLocation.size() == 0)
         return false;
-    
+
     std::string path = _sdCardFolderLocation + "/" + std::string(filepath);
     if (exists(filepath)) {
-        std::string cmd = std::string("rm -rf ") + std::string(path);
-        system(cmd.c_str());
+        try {
+            fs::remove_all(path);
+        } catch (const std::exception &e) {
+            Serial.printf("Unable to remove '%s'\n", filepath);
+        }
         return true;
     }
     return true;

--- a/test/test_paths_with_spaces.cpp
+++ b/test/test_paths_with_spaces.cpp
@@ -1,0 +1,44 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+// Regression test for issue #12: SD.mkdir/rmdir/remove used to shell out via
+// system() with unquoted paths, which breaks on paths containing spaces (and
+// is a command-injection risk). With the std::filesystem implementation these
+// operations work correctly regardless of spaces in the path.
+BOOST_AUTO_TEST_SUITE(paths_with_spaces_tests)
+
+    BOOST_FIXTURE_TEST_CASE(mkdir_remove_handle_spaces, DefaultTestFixture) {
+        SD.setSDCardFolderPath("output", true);
+
+        const char *dirName = "a folder";
+        const char *filePath = "a folder/my file.txt";
+
+        // Clean up any artifacts left over from a previous run.
+        if (SD.exists(dirName)) {
+            SD.rmdir(dirName);
+        }
+        BOOST_CHECK(!SD.exists(dirName));
+
+        // Create a directory whose name contains a space.
+        BOOST_CHECK(SD.mkdir(dirName));
+        BOOST_CHECK(SD.exists(dirName));
+
+        // Write a file (with a space in its name) inside that directory.
+        File write_file = SD.open(filePath, O_WRITE);
+        if (!write_file) {
+            BOOST_FAIL("File with a space in its path was not opened (for write)...");
+        }
+        write_file.write((const uint8_t *)"hello world", 11);
+        write_file.close();
+        BOOST_CHECK(SD.exists(filePath));
+
+        // remove() should delete the file (recursively handles dirs/files).
+        SD.remove(filePath);
+        BOOST_CHECK(!SD.exists(filePath));
+
+        // rmdir() should delete the directory itself.
+        SD.rmdir(dirName);
+        BOOST_CHECK(!SD.exists(dirName));
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Problem

`SDClass::mkdir`, `rmdir`, and `remove` (`src/SD.cpp`) built shell command strings (`mkdir -p`, `rm -rf`) and invoked them via `system()`. The `rmdir`/`remove` variants passed the path **unquoted**, so any path containing a space broke the command, and arbitrary path content was a command-injection risk. `mkdir` quoted its argument but was still shell-based.

## Fix

Replace the `system()` calls with `std::filesystem` (no shell involved):

- `mkdir` -> `fs::create_directories(path)`. The existing "already exists -> return true" behaviour is preserved (the function still guards with `exists()`, and `create_directories` returning `false` for an existing dir is treated as success).
- `rmdir` and `remove` -> `fs::remove_all(path)`, which handles both files and directories recursively, matching the previous `rm -rf` semantics.

All three are wrapped in try/catch, preserving the original return values and `Serial` diagnostic messages. The path-construction logic (prepending `_sdCardFolderLocation`) is unchanged.

## C++17 bump

`<filesystem>` requires C++17. `src/CMakeLists.txt` is bumped from `CMAKE_CXX_STANDARD 14` to `17`, and `target_compile_features(teensy_x86_sd_stubs PUBLIC cxx_std_17)` is added so consumers (the test executable) inherit the C++17 requirement transitively. `test/CMakeLists.txt` is intentionally left untouched.

## Test

Adds `test/test_paths_with_spaces.cpp` (regression for this issue): maps `output/` as the SD root, creates a directory named `"a folder"`, asserts it exists, writes a file with a space in its name inside it, asserts that exists, then `remove`s the file and `rmdir`s the directory and asserts both are gone. Before the fix, the unquoted shell-out would mishandle the spaces. The file is picked up automatically by the test glob (no CMake edit).

## Risks

- Requires C++17; CI uses ubuntu-latest with a modern GCC, where `<filesystem>` does not need linking against `stdc++fs`, so no extra link flag is added.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_