### PR TITLE
Minor cleanups: logical and, signed/unsigned, const-correctness

### DIFF
--- a/src/InMemoryFile.cpp
+++ b/src/InMemoryFile.cpp
@@ -20,10 +20,14 @@ bool InMemoryFile::isDirectory(void) {
 }
 
 size_t InMemoryFile::write(uint8_t val) {
+    // Routes through the buffer write below; in-memory mode is read-only.
     return write(&val, 1);
 }
 
 size_t InMemoryFile::write(const uint8_t *buf, size_t size) {
+    // In-memory mode is read-only: writes are intentionally a no-op and
+    // report zero bytes written. The mock backs a single read-only buffer
+    // supplied via SD.setSDCardFileData(); use folder-backed mode for writes.
     return 0;
 }
 
@@ -32,7 +36,9 @@ int InMemoryFile::peek() {
 }
 
 int InMemoryFile::read() {
-    if (_position >= _size) {
+    // _size is int32_t with -1 as the empty/sentinel value; treat that as
+    // empty rather than comparing _position against a huge unsigned value.
+    if (_size < 0 || _position >= static_cast<uint32_t>(_size)) {
         std::cout << "!!! CRITICAL: read outside bounds of file...";
         return 0;
     }
@@ -45,8 +51,10 @@ int InMemoryFile::read() {
 // buffered read for more efficient, high speed reading
 int InMemoryFile::read(void *buf, uint32_t nbyte) {
     char * target = (char*)buf;
-    for (int i=0; i < nbyte; i++) {
-        if  (_position >= _size)
+    for (uint32_t i=0; i < nbyte; i++) {
+        // _size is int32_t with -1 as the empty/sentinel value; treat that as
+        // empty rather than comparing _position against a huge unsigned value.
+        if (_size < 0 || _position >= static_cast<uint32_t>(_size))
             return i;
         int byteRead = read();
         target[i] = static_cast<char>(byteRead);
@@ -55,7 +63,7 @@ int InMemoryFile::read(void *buf, uint32_t nbyte) {
 }
 
 int InMemoryFile::available() {
-    return _isOpen & (_position < _size);
+    return _isOpen && (_size >= 0) && (_position < static_cast<uint32_t>(_size));
 }
 
 void InMemoryFile::flush() {

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -416,13 +416,14 @@ File SDClass::open(const char *filepath, uint8_t mode) {
         std::string pathString = std::string(filepath);
         std::string fileNameString = std::string(filepath);
         size_t last_slash_idx = pathString.rfind('/');
-        char *path = "";
+        const char *path = "";
         if (std::string::npos != last_slash_idx)
         {
             fileNameString = fileNameString.substr(last_slash_idx+1, strlen(filepath)-last_slash_idx-1);
             std::string temppath = pathString.substr(0, last_slash_idx);
-            path = new char[temppath.length() + 1] {0};
-            memcpy(path, temppath.c_str(), temppath.length());
+            char *pathBuf = new char[temppath.length() + 1] {0};
+            memcpy(pathBuf, temppath.c_str(), temppath.length());
+            path = pathBuf;
         }
         result = new LinuxFile(fileNameString.c_str(), path, mode, *this);
     }

--- a/test/test_inmemory.cpp
+++ b/test/test_inmemory.cpp
@@ -1,0 +1,31 @@
+#include <boost/test/unit_test.hpp>   // do NOT define BOOST_TEST_MODULE here
+#include "default_test_fixture.h"
+
+BOOST_AUTO_TEST_SUITE(inmemory_tests)
+
+    BOOST_FIXTURE_TEST_CASE(can_read_inmemory_buffer, DefaultTestFixture) {
+        const char *expected = "abcdef";
+
+        SD.setSDCardFileData((char*)"abcdef", 6);
+
+        // In in-memory mode any filename returns the one backing buffer.
+        File f = SD.open("anything");
+        if (!f) {
+            BOOST_FAIL("In-memory file was not opened...");
+        }
+
+        BOOST_CHECK(f.available());
+
+        char buffer[6] = {0};
+        int numBytesRead = f.read(buffer, 6);
+        BOOST_CHECK_EQUAL(numBytesRead, 6);
+        BOOST_CHECK_EQUAL_COLLECTIONS(&buffer[0], &buffer[6], &expected[0], &expected[6]);
+
+        // After reading the whole buffer, available() must report false
+        // (exercises the && / signed-unsigned guard in available()).
+        BOOST_CHECK(!f.available());
+
+        f.close();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Bundle of minor cleanups from issue #13. Behavioral no-op for valid files.

## Cleanups

1. **`InMemoryFile::available()` — logical vs bitwise.** Changed `_isOpen & (_position < _size)` to use `&&`. While here, also guarded the signed/unsigned comparison consistently with the read path (see #2 below): `_isOpen && (_size >= 0) && (_position < static_cast<uint32_t>(_size))`.

2. **Signed/unsigned comparisons in the read path.** The buffered-read loop `for (int i=0; i < nbyte; i++)` compared `int` against `uint32_t nbyte`; `i` is now `uint32_t`. The `_position >= _size` checks in both `read()` and `read(void*, uint32_t)` compared a `uint32_t` (`_position`) against an `int32_t` (`_size`, whose empty/sentinel value is `-1`). Added a `_size < 0` guard so the sentinel is treated as empty rather than promoting `-1` to a huge unsigned value, and cast `_size` to `uint32_t` for the in-range comparison. Behavior for valid files is unchanged.

3. **Documented the in-memory read-only write no-op.** `InMemoryFile::write(const uint8_t*, size_t)` (and the single-byte overload that routes through it) intentionally return 0. Added comments explaining in-memory mode is read-only; no behavior change.

4. **`const`-correctness in `SDClass::open`.** Changed `char *path = "";` to `const char *path = "";` to avoid the string-literal-to-`char*` assignment. The later allocation now goes through a `char *pathBuf` temp that is assigned into the `const char *`. `LinuxFile`'s constructor already takes `const char *path`, so this compiles unchanged.

## Test

Added `test/test_inmemory.cpp` (no `BOOST_TEST_MODULE`, uses `DefaultTestFixture`, suite `inmemory_tests`). It exercises the in-memory read path touched above: sets a 6-byte buffer via `SD.setSDCardFileData`, opens a file, reads all 6 bytes asserting content `"abcdef"`, and checks `available()` is true before and false after reading the whole buffer. `test/CMakeLists.txt` globs `test_*.cpp`, so no CMake edits are needed.

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185TN98hBMrsQoJNNVZvyad)_